### PR TITLE
feature: adds integration for subscription_types on contacts stream

### DIFF
--- a/tap_hubspot/schemas/subscription_types.json
+++ b/tap_hubspot/schemas/subscription_types.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "properties": {
+    "recipient": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "subscriptionStatuses": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "name": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "description": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "status": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "sourceOfStatus": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "preferenceGroupName": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "legalBasis": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "legalBasisExplanation": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
# Description of change

Added the subscription_types on the contract stream.


# Manual QA steps
 - Get a valid config.json with `communication_preferences.read` scope enabled
 - Run catalog generation and singer discover, selecting only the contacts stream
 - Run `python tap_hubspot/__init__.py --config config.json --properties catalog-selected.json > data.txt`
 
 
# Rollback steps
 - revert this branch
