### PR TITLE
HGI-5432 \ Add jitter to always wait 120s when retrying

### DIFF
--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -290,12 +290,14 @@ def get_params_and_headers(params):
 
     return params, headers
 
+def jitter_120(value):
+    return 120
 
 @backoff.on_exception(backoff.constant,
                       (requests.exceptions.RequestException,
                        requests.exceptions.HTTPError),
                       max_tries=5,
-                      jitter=None,
+                      jitter=jitter_120,
                       giveup=giveup,
                       on_giveup=on_giveup,
                       interval=10)

--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -296,14 +296,16 @@ def get_params_and_headers(params):
 
     return params, headers
 
-@backoff.on_exception(backoff.constant,
+@backoff.on_exception(backoff.expo,
                       (requests.exceptions.RequestException,
                        requests.exceptions.HTTPError),
                       max_tries=5,
                       jitter=None,
                       giveup=giveup,
                       on_giveup=on_giveup,
-                      interval=10)
+                      base=2,
+                      factor=5,
+                      max_value=60)
 def request(url, params=None):
 
     params, headers = get_params_and_headers(params)


### PR DESCRIPTION
# Description of change
`contact/v1/lists` endpoint was raising 429 error and excepted after the 5 retries. Add jitter to guarantee 120s between retries

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
